### PR TITLE
fix: Set correct protection bits

### DIFF
--- a/config.h
+++ b/config.h
@@ -67,6 +67,7 @@ This means that this file has had too many modifications to be safely replaceabl
 //--Modified 2020-07-03 by C.W. Betts to enable automatically for ARM
 #if defined(__arm64__)
 	#define C_DYNREC 1
+    #define PAGESIZE 0x4000
 #endif
 //--End of modifications
 

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -602,7 +602,7 @@ static void cache_init(bool enable) {
 			cache_code=cache_code+PAGESIZE_TEMP;
 
 #if (C_HAVE_MPROTECT)
-			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_WRITE|PROT_READ|PROT_EXEC))
+			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_WRITE|PROT_READ) != 0)
 				LOG_MSG("Setting execute permission on the code cache has failed");
 #endif
 			CacheBlockDynRec * block=cache_getblock();
@@ -626,6 +626,11 @@ static void cache_init(bool enable) {
 		core_dynrec.runcode=(BlockReturn (*)(Bit8u*))cache.pos;
 //		link_blocks[1].cache.start=cache.pos;
 		dyn_run_code();
+		
+#if (C_HAVE_MPROTECT)
+			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_EXEC|PROT_READ) != 0)
+				LOG_MSG("Setting execute permission on the code cache has failed");
+#endif
 
 		cache.free_pages=0;
 		cache.last_page=0;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -32,6 +32,13 @@
 */
 
 static CacheBlockDynRec * CreateCacheBlock(CodePageHandlerDynRec * codepage,PhysPt start,Bitu max_opcodes) {
+
+#if (C_HAVE_MPROTECT)
+			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_WRITE|PROT_READ) != 0)
+				LOG_MSG("Setting execute permission on the code cache has failed");
+#endif
+
+	
 	// initialize a load of variables
 	decode.code_start=start;
 	decode.code=start;
@@ -607,6 +614,11 @@ illegalopcode:
 	dyn_closeblock();
 	goto finish_block;
 finish_block:
+
+#if (C_HAVE_MPROTECT)
+			if(mprotect(cache_code_link_blocks,CACHE_TOTAL+CACHE_MAXSIZE+PAGESIZE_TEMP,PROT_EXEC|PROT_READ) != 0)
+				LOG_MSG("Setting execute permission on the code cache has failed");
+#endif
 
 	// setup the correct end-address
 	decode.page.index--;


### PR DESCRIPTION
This PR ensures `mprotect` is called to flip appropriate protection bits to write and execute JIT pages. Apple silicon is W^X (write / execute exclusive).

I hard-coded the page size to 0x4000, but the real solution would be to use `vm_page_size` global variable, but that will take more effort to plumb through.